### PR TITLE
url strings to URI objects (handles http/https redirect)

### DIFF
--- a/t/03-cookies.t
+++ b/t/03-cookies.t
@@ -6,7 +6,8 @@ use HTTP::Response;
 
 plan 24;
 
-my $file = './cookies.dat';
+BEGIN my $file = './cookies.dat';
+LEAVE try $file.IO.unlink;
 
 my $c = HTTP::Cookies.new(
     file     => $file,

--- a/t/10-redirect-ssl.t
+++ b/t/10-redirect-ssl.t
@@ -10,10 +10,13 @@ BEGIN {
 
 use Test;
 
-plan 1;
+plan 2;
 
 my $url = 'http://github.com';
-my $ua  = HTTP::UserAgent.new(GET => $url);
+
+my $ua;
+lives_ok { $ua  = HTTP::UserAgent.new(GET => $url) }, 'new(GET => $url) lives';
+
 my $get = ~$ua.get($url);
 
 ok $get ~~ /'</html>'/, 'http -> https redirect get 1/1';

--- a/t/10-redirect-ssl.t
+++ b/t/10-redirect-ssl.t
@@ -1,0 +1,19 @@
+use v6;
+
+use HTTP::UserAgent;
+BEGIN {
+    if ::('IO::Socket::SSL') ~~ Failure {
+        print("1..0 # Skip: IO::Socket::SSL not available\n");
+        exit 0;
+    }
+}
+
+use Test;
+
+plan 1;
+
+my $url = 'http://github.com';
+my $ua  = HTTP::UserAgent.new(GET => $url);
+my $get = ~$ua.get($url);
+
+ok $get ~~ /'</html>'/, 'http -> https redirect get 1/1';


### PR DESCRIPTION
From @FROGGS suggestion I replaced Str $urls with URI $uris. This should automatically handle changing the port to 443 when redirected to https *unless* the port is set in the url like https://github.com:8080 in $header.<Location>.

It may be wise to add a no-redirect option in the future so the user may handle these manually.

re issue #38 and PR #40 