### PR TITLE
Allow charset to have an extra ; at the end

### DIFF
--- a/lib/HTTP/UserAgent.pm6
+++ b/lib/HTTP/UserAgent.pm6
@@ -184,7 +184,7 @@ multi method get($uri is copy where URI|Str) {
             $response.content = $content;
             my $content-type  = $response.header.field('Content-Type').values[0] // '';
             if $content-type ~~ /^ text / {
-                my $charset = $content-type ~~ / charset '=' $<charset>=[ \S+ ] /
+                my $charset = $content-type ~~ / charset '=' $<charset>=[ <-[\s;]>+ ] /
                             ?? $<charset>.Str.lc
                             !! 'ascii';
                 $response.content = Encode::decode($charset, $response.content);


### PR DESCRIPTION
Some websites have an extra semicolon at the end of their Content-Type
header, after the charset parameter, which causes decoding content to
fail. A brief reading of the HTTP 1.1 spec implies that this is not
explicitly permitted, but the web is not always up to spec. P6's
LWP::Simple also allows this.

Aside from fixing this specific case, I would also like to suggest handling decoding errors more gracefully somehow. I don't have a good idea on how to do this, but something to allow users to get the raw bytes and headers seems useful for debugging or for interacting with broken web services.