### PR TITLE
::Message to decode for .get; add decode fallback [fixes #35]

### DIFF
--- a/lib/HTTP/UserAgent.pm6
+++ b/lib/HTTP/UserAgent.pm6
@@ -117,7 +117,7 @@ multi method get($uri is copy where URI|Str) {
         # +2 because we need a trailing CRLF in the header.
         $msg-body-pos   += 2 if $msg-body-pos >= 0;
 
-        my ($response-line, $header) = _split_buf("\r\n", $first-chunk.subbuf(0, $msg-body-pos), 2)>>.decode('ascii');
+        my ($response-line, $header) = _split_buf("\r\n", $first-chunk.subbuf(0, $msg-body-pos), 2)».decode('ascii');
         $response .= new( $response-line.split(' ')[1].Int );
         $response.header.parse( $header );
 

--- a/t/08-ua.t
+++ b/t/08-ua.t
@@ -3,7 +3,7 @@ use HTTP::UserAgent;
 use HTTP::UserAgent::Common;
 use Test;
 
-plan 7;
+plan 8;
 
 # new
 my $ua = HTTP::UserAgent.new;
@@ -24,3 +24,6 @@ my $response = $ua.get('filip.sergot.pl/');
 ok $response, 'get 1/3';
 isa_ok $response, HTTP::Response, 'get 2/3';
 ok $response.is-success, 'get 3/3';
+
+# non-ascii encodings (github issue #35)
+lives_ok { HTTP::UserAgent.new.get('http://www.baidu.com') }, 'Lived through gb2312 encoding';


### PR DESCRIPTION
Resolves #35 

HTTP::Message and HTTP::UserAgent had the same decode logic, so
I removed it from UserAgent and used the $request object's message
object's decode-content method. I *think* this was an artifact from
when the content was stored in a my $content instead of the
$response.content attribute.

The decode-content logic was changed to use a saner default of utf-8
unless content-type contains 'text/' (which uses ascii by default
per rfc). However, an additional step should eventually be added
for when the charset is missing from the header; it should attempt
to extract the charset from the $response body meta tag attributes
(chicken and egg problem?). Issue #35 covers this: baidu.com does
not send a charset in the header, but it *is* in the html's meta tag.

It is also probably advisable to figure out a way to upgrade uint8 to either uint16 or uint32 for when it needs to hold some of the larger encodings:

    nickl@localhost:~/perl6/http-useragent$ perl6 -e 'my $buf = Blob[uint8].new(0x30F9); say $buf.perl; say $buf.unpack("A*");'
    Blob[uint8].new(249)
    ù

    nickl@localhost:~/perl6/http-useragent$ perl6 -e 'my $buf = Blob[uint16].new(0x30F9); say $buf.perl; say $buf.unpack("A*");'
    Blob[uint16].new(12537)
    ヹ
