### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/HTTP/Cookie.pm6
+++ b/lib/HTTP/Cookie.pm6
@@ -1,4 +1,4 @@
-class HTTP::Cookie;
+unit class HTTP::Cookie;
 
 has $.name is rw;
 has $.value is rw;

--- a/lib/HTTP/Cookies.pm6
+++ b/lib/HTTP/Cookies.pm6
@@ -1,4 +1,4 @@
-class HTTP::Cookies;
+unit class HTTP::Cookies;
 
 use HTTP::Cookie;
 use HTTP::Response;

--- a/lib/HTTP/Header.pm6
+++ b/lib/HTTP/Header.pm6
@@ -1,4 +1,4 @@
-class HTTP::Header;
+unit class HTTP::Header;
 
 use HTTP::Header::Field;
 

--- a/lib/HTTP/Header/Field.pm6
+++ b/lib/HTTP/Header/Field.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class HTTP::Header::Field;
+unit class HTTP::Header::Field;
 
 has $.name;
 has @.values;

--- a/lib/HTTP/Message.pm6
+++ b/lib/HTTP/Message.pm6
@@ -1,4 +1,4 @@
-class HTTP::Message;
+unit class HTTP::Message;
 
 use HTTP::Header;
 use Encode;

--- a/lib/HTTP/Request.pm6
+++ b/lib/HTTP/Request.pm6
@@ -2,7 +2,7 @@ use HTTP::Message;
 
 use URI;
 
-class HTTP::Request is HTTP::Message;
+unit class HTTP::Request is HTTP::Message;
 
 has $.method is rw;
 has $.url is rw;

--- a/lib/HTTP/Response.pm6
+++ b/lib/HTTP/Response.pm6
@@ -1,7 +1,7 @@
 use HTTP::Message;
 use HTTP::Status;
 
-class HTTP::Response is HTTP::Message;
+unit class HTTP::Response is HTTP::Message;
 
 has $.status-line is rw;
 has $.code is rw;

--- a/lib/HTTP/UserAgent.pm6
+++ b/lib/HTTP/UserAgent.pm6
@@ -1,4 +1,4 @@
-class HTTP::UserAgent;
+unit class HTTP::UserAgent;
 
 use HTTP::Response;
 use HTTP::Request;

--- a/lib/HTTP/UserAgent/Common.pm6
+++ b/lib/HTTP/UserAgent/Common.pm6
@@ -1,4 +1,4 @@
-module HTTP::UserAgent::Common;
+unit module HTTP::UserAgent::Common;
 
 my %useragents =
 chrome_w7_64   => 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 Safari/537.36',


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.