### PR TITLE
make header fileds case-insensitive when setting them

### DIFF
--- a/lib/HTTP/Header.pm6
+++ b/lib/HTTP/Header.pm6
@@ -52,7 +52,7 @@ multi method field(*%fields) {
     for %fields.kv -> $k, $v {
         my $f = HTTP::Header::Field.new(:name($k), :values($v.list));
         if @.fields.first({ .name.lc eq $k.lc }) {
-            @.fields[@.fields.first-index({ .name eq $k })] = $f;
+            @.fields[@.fields.first-index({ .name.lc eq $k.lc })] = $f;
         } else {
             @.fields.push: $f;
         }


### PR DESCRIPTION
In #82, header fields are case-insensitive when getting them.
This PR makes them case-insensitive when setting them too.