### PR TITLE
removed the "try" keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SYNOPSIS
     my $ua = HTTP::UserAgent.new;
     $ua.timeout = 10;
 
-    try my $response = $ua.get("URL");
+    my $response = $ua.get("URL");
 
     if $response.is-success {
         say $response.content;


### PR DESCRIPTION
Hi! Thanks for the great work on HTTP::UserAgent, I love it!

Now, if I understood correctly how Perl 6 exception handling works, there is no "try" keyword. Instead, when an exception is raised, it is captured by a CATCH {} block within the current block. So, if we were to write Perl 6 code to silence exceptions, it should be something like:

```perl6
    my $response = $ua.get("URL");
    CATCH {}
```

However, since silencing exceptions doesn't really look like the best way to write code, I simply removed the "try" keyword from the example. It fits with the code in `ex_readme.p6`.

Hope this helps!