### PR TITLE
Windows CRLF test errors. Network access is not guaranteed.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+t/dat/foo.txt         eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-t/dat/foo.txt         eol=lf

--- a/t/080-ua.t
+++ b/t/080-ua.t
@@ -16,6 +16,12 @@ my $newua = get-ua('chrome_linux');
 $ua = HTTP::UserAgent.new(:useragent('chrome_linux'));
 is $ua.useragent, $newua, 'new 3/3';
 
+unless %*ENV<NETWORK_TESTING> {
+  diag "Skipped some live tests since NETWORK_TESTING was not set";
+  skip-rest("Tests require network access");
+  exit;
+}
+
 # user agent
 is $ua.get('http://ua.offensivecoder.com/').content, "$newua\n", 'useragent 1/1';
 


### PR DESCRIPTION
- Some fixes for windows CRLF git auto conversion.
- require NETWORK_TESTING for live tests.