### PR TITLE
Import some network tests using w3 test pages with odd encodings.

### DIFF
--- a/lib/HTTP/Message.pm6
+++ b/lib/HTTP/Message.pm6
@@ -38,6 +38,8 @@ method decoded-content {
         $!content.unpack("A*") 
     } or die "Problem decoding content";
 
+    $decoded_content = $!content.decode('iso-8859-1') if !$decoded_content.defined and $!content.defined;
+
     $decoded_content
 }
 

--- a/t/200-w3-test-encodings.t
+++ b/t/200-w3-test-encodings.t
@@ -1,0 +1,24 @@
+# TODO probably should contain Bufs of data and test HTTP::Message
+# directly rather than go over the wire.
+
+use v6;
+use HTTP::UserAgent;
+use Test;
+
+my @tests = 3..9; # TODO 1 and 2
+plan @tests.elems;
+
+unless %*ENV<NETWORK_TESTING> {
+    diag "NETWORK_TESTING was not set";
+    skip-rest("NETWORK_TESTING was not set");
+    exit;
+}
+
+my $ua = HTTP::UserAgent.new;
+
+for @tests -> $i {
+    my $url = "http://www.w3.org/2006/11/mwbp-tests/test-encoding-{$i}.html";
+    my $res =  $ua.get($url);
+    ok $res.content ~~ / 'é' /, "got correctly encoded é {$i} from w3.org" or warn :$url.perl;
+}
+


### PR DESCRIPTION
Fix two of those tests by falling back to guessing latin-1 ish
encodings in HTTP::Message