### PR TITLE
Implement proper decoding fix

### DIFF
--- a/lib/HTTP/Message.pm6
+++ b/lib/HTTP/Message.pm6
@@ -34,11 +34,9 @@ method decoded-content {
 
     my $decoded_content = try {
         Encode::decode($charset, $!content);
-    } or try { 
+    } || try { 
         $!content.unpack("A*") 
-    } or die "Problem decoding content";
-
-    $decoded_content = $!content.decode('iso-8859-1') if !$decoded_content.defined and $!content.defined;
+    } || die "Problem decoding content";
 
     $decoded_content
 }


### PR DESCRIPTION
As already suggested and exampled, but for some reason ignored:

The previous problem was a precedence issue with `or` and `||`. Adding an additional decode will make it slower (it will end up decoding 3 times in some instances) as well as throw a completely different exception when the decoding fails.