### PR TITLE
When parsing a HTTP::Request, set $.uri attribute

### DIFF
--- a/lib/HTTP/Request.pm6
+++ b/lib/HTTP/Request.pm6
@@ -115,6 +115,8 @@ method parse($raw_request) {
 
     $.url ~= $.file;
 
+    self.uri( $.url );
+
     nextsame;
 
     self;


### PR DESCRIPTION
Hi,

when parsing an HTTP Request from a string, the $.url is set, however the $.uri is not set.
After parsing the $url, just use the $.uri setter to set the value.

Pierre