### PR TITLE
Keeping Cookies Through 302 Redirection

### DIFF
--- a/lib/HTTP/UserAgent.pm6
+++ b/lib/HTTP/UserAgent.pm6
@@ -165,6 +165,9 @@ method request(HTTP::Request $request, Bool :$bin) returns HTTP::Response {
     self.save-response($response);
     $.debug-handle.say("<<==Recv\n" ~ $response.Str(:debug)) if $.debug;
 
+    # save cookies
+    $.cookies.extract-cookies($response);
+
     given $response.code {
         when /^30<[0123]>/ { 
             when $.max-redirects < +@.history
@@ -186,8 +189,6 @@ method request(HTTP::Request $request, Bool :$bin) returns HTTP::Response {
         }
     }        
 
-    # save cookies
-    $.cookies.extract-cookies($response);
     return $response;
 }
 

--- a/t/110-redirect-cookies.t
+++ b/t/110-redirect-cookies.t
@@ -1,0 +1,19 @@
+#!perl6
+
+use v6;
+
+use Test;
+use HTTP::UserAgent;
+
+use lib $*PROGRAM.parent.child('lib').Str;
+
+use TestServer;
+
+my $test-server = test-server(my $done-promise = Promise.new, port => my $port = 3333);
+my $ua          = HTTP::UserAgent.new;
+
+plan 1;
+
+ok $ua.get("http://localhost:$port/one").is-success, 'redirect preserves cookies';
+
+$done-promise.keep("shutdown");

--- a/t/lib/TestServer.pm
+++ b/t/lib/TestServer.pm
@@ -21,9 +21,11 @@ module TestServer {
                 }
                 whenever IO::Socket::Async.listen('localhost',$port) -> $conn {
                     my Buf $in-buf = Buf.new;
+                    my Str $req-line;
                     whenever $conn.Supply(:bin) -> $buf { 
                         if $in-buf.elems == 0 {
                             my $header-end = _index_buf($buf, Buf.new(13,10));
+                            $req-line = $buf.subbuf(0, $header-end).decode;
                             $in-buf ~= $buf.subbuf($header-end + 2);
                         }
                         else {
@@ -34,7 +36,21 @@ module TestServer {
                         if (my $header-end = _index_buf($in-buf, Buf.new(13,10,13,10))) > 0 {
                             my $header = $in-buf.subbuf(0, $header-end).decode('ascii');
 
-                            if $header ~~ /Content\-Length\:\s+$<length>=[\d+]/ {
+                            if $req-line ~~ /^GET \s+ \/one/ {
+                                $conn.write: "HTTP/1.1 302 Found\r\nLocation: /two\r\nSet-Cookie: test=abc\r\n\r\n".encode;
+                                $conn.close;
+                            }
+
+                            elsif $req-line ~~ /^GET \s+ \/?two/ {
+                                if ( $header ~~ /Cookie\: \s+ test\=abc/ ) {
+                                    $conn.write: "HTTP/1.1 200 OK\r\n\r\n".encode;
+                                } else {
+                                    $conn.write: "HTTP/1.1 404 Not Found\r\n\r\n".encode;
+                                }
+                                $conn.close;
+                            }
+
+                            elsif $header ~~ /Content\-Length\:\s+$<length>=[\d+]/ {
                                 my $length = $<length>.Int; 
                                 if $in-buf.subbuf($header-end + 4) == $length {
                                     await $conn.write: "HTTP/1.0 200 OK\r\n".encode ~ $in-buf ;


### PR DESCRIPTION
When trying to mechanize a web login, I noticed that the site returned a "302 Found" redirect with the Session Token in a cookie.

Unfortunately, HTTP::UserAgent wasn't preserving that cookie when it fetched the subsequent URL from the "Location:" header, so it kept bouncing me back to the login page.

The problem was that HTTP::UserAgent wasn't calling `$.cookies.extract-cookies($response)` until _*after*_ it performed the redirection...  The fix is simple:

```
--- a/lib/HTTP/UserAgent.pm6
+++ b/lib/HTTP/UserAgent.pm6
@@ -165,6 +165,9 @@ method request(HTTP::Request $request, Bool :$bin) returns HTTP::Response {
     self.save-response($response);
     $.debug-handle.say("<<==Recv\n" ~ $response.Str(:debug)) if $.debug;

+    # save cookies
+    $.cookies.extract-cookies($response);
+
     given $response.code {
         when /^30<[0123]>/ {
             when $.max-redirects < +@.history
@@ -186,8 +189,6 @@ method request(HTTP::Request $request, Bool :$bin) returns HTTP::Response {
         }
     }

-    # save cookies
-    $.cookies.extract-cookies($response);
     return $response;
 }
```
 
I added a quick-n-dirty test, as well...