### PR TITLE
Fix failures due to broken httpstat.us website

### DIFF
--- a/t/082-exceptions.t
+++ b/t/082-exceptions.t
@@ -7,14 +7,14 @@ use HTTP::UserAgent;
 my $ua = HTTP::UserAgent.new;
 my $res;
 
-lives-ok { $res = $ua.get('http://httpstat.us/404') }, "no exception - expect 404";
+lives-ok { $res = $ua.get('http://httpbin.org/status/404') }, "no exception - expect 404";
 
 ok !$res.is-success, "and it isn't successful";
 is $res.code, 404, "and a 404";
 
 $ua = HTTP::UserAgent.new(:throw-exceptions);
 
-throws-like {  $ua.get('http://httpstat.us/404') }, X::HTTP::Response, message => "Response error: '404 Not Found'", response => HTTP::Response;
+throws-like {  $ua.get('http://httpbin.org/status/404') }, X::HTTP::Response, message => "Response error: '404 Not Found'", response => HTTP::Response;
 
 done-testing;
 

--- a/t/190-issue-116.t
+++ b/t/190-issue-116.t
@@ -14,7 +14,7 @@ if ::('IO::Socket::SSL') ~~ Failure {
 my $ua = HTTP::UserAgent.new;
 
 my HTTP::Response $res;
-my $request = HTTP::Request.new(GET => 'http://httpstat.us/304');
+my $request = HTTP::Request.new(GET => 'http://httpbin.org/status/304');
 lives-ok { $res = $ua.request($request) }, "another request that always results in 304 lives";
 is $res.code , 304, "and it is actually a 304";
 


### PR DESCRIPTION
The site used seems to not work anymore. This fixes the two test files in question, as the site they use seems to not work anymore.

Part of fixing #167
Fixes failures shown on https://github.com/zoffixznet/perl6-WWW/issues/1

