### PR TITLE
Save memory by not storing full request history

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,7 +1,7 @@
 {
     "perl"      : "6.c",
     "name"      : "HTTP::UserAgent",
-    "version"   : "1.1.30",
+    "version"   : "1.1.31",
     "author"   : "github:sergot",
     "description"   : "Web user agent",
     "depends"   : [


### PR DESCRIPTION
See #169.

We used to store the full history of the response, just to count redirects.
This used up lots of RAM for very little gain.

This commit replaces it by a simple integer that stores the count of
redirects in a row.

Since `@.history` was a public attribute, this changes the public API,
and as such is subject to discussion.