### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"      : "6.c",
     "name"      : "HTTP::UserAgent",
+    "license"   : "MIT",
     "version"   : "1.1.31",
     "author"   : "github:sergot",
     "description"   : "Web user agent",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license