### PR TITLE
Add oneline option to encode-str to avoid basic auth header to wrap

### DIFF
--- a/lib/HTTP/UserAgent.pm6
+++ b/lib/HTTP/UserAgent.pm6
@@ -414,7 +414,7 @@ multi sub basic-auth-token(Str $login, Str $passwd ) returns Str {
 }
 
 multi sub basic-auth-token(Str $creds where * ~~ /':'/) returns Str {
-    "Basic " ~ MIME::Base64.encode-str($creds);
+    "Basic " ~ MIME::Base64.encode-str($creds, :oneline);
 }
 
 method setup-auth(HTTP::Request $request) {


### PR DESCRIPTION
When the username and password is more than 76 characters, which is easy to get for REST API calls with auth tokens, the basic header wraps and thus the basic auth fails. Setting oneline option to encode-str avoids this.