### PR TITLE
- Fixes issue where header fields that had a value starting with 'W'

### DIFF
--- a/t/010-headers.t
+++ b/t/010-headers.t
@@ -2,7 +2,7 @@ use Test;
 
 use HTTP::Header;
 
-plan 19;
+plan 23;
 
 # new
 my $h = HTTP::Header.new(a => "A", b => "B");
@@ -53,8 +53,15 @@ is $h.hash<Two>, "two", "Got two (hash 2/2)";
 
 $h = HTTP::Header.new();
 
-lives-ok { $h.parse('ETag: W/"1201-51b0ce7ad3900"') }, "parse";
+lives-ok { $h.parse('ETag: W/"1201-51b0ce7ad3900"') }, "parses ETag";
 is ~$h.field('ETag'), "1201-51b0ce7ad3900", "got the value we expected";
+
+lives-ok { $h.parse('expires: Wed, 27 Jan 2016 17:44:43 GMT') }, "parses date on a Wed";
+ok $h.field('expires') ~~ /^^Wed/, "Does not trip start of field value starting with 'W'";
+
+# ugexe++ -- See http://irclog.perlgeek.de/perl6/2017-09-27#i_15227591
+lives-ok { $h.parse('Custom-Auth-Header: W/7fhEfhkjafeHF') }, "parses ETag like";
+is ~$h.field('Custom-Auth-Header'), 'W/7fhEfhkjafeHF', 'got the non truncated value';
 
 subtest {
    my $htest = q:to/EOH/;


### PR DESCRIPTION
This issue was causing problems, particularly with date headers where that date fell on a Wednesday.

Due to the existing ETag handling, the "W" in Wednesday was dropped. This is a tentative fix where we force a "W/" or a "w/" for ETags, while preserving the ability for a field to start with "W/" (as in Base64 values" if the field name is not "ETag". That check is performed in a case insensitive manner.

Please let me know if this PR is acceptable or if it needs changes.