### PR TITLE
Update tests for new hash randomization. Bump version

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -44,10 +44,10 @@
     "HTTP::UserAgent": "lib/HTTP/UserAgent.pm6",
     "HTTP::UserAgent::Common": "lib/HTTP/UserAgent/Common.pm6"
   },
-  "version": "1.1.39",
+  "version": "1.1.40",
   "meta-version": "0",
   "authors": [
-    "sergot"    
+    "sergot"
   ],
   "description": "Web user agent"
 }

--- a/t/010-headers.t
+++ b/t/010-headers.t
@@ -35,8 +35,8 @@ is any($h.header-field-names), 'a', 'header-field-names 2/3';
 is any($h.header-field-names), 'b', 'header-field-names 3/3';
 
 # Str
-is $h.Str, "a: a, a2, a3\nb: B\n", 'Str 1/2';
-is $h.Str('|'), 'a: a, a2, a3|b: B|', 'Str 2/2';
+is-deeply $h.Str, "a: a, a2, a3\nb: B\n", 'Str 1/2';
+is-deeply $h.Str('|'), 'a: a, a2, a3|b: B|', 'Str 2/2';
 
 # remove-field
 $h.remove-field('a');

--- a/t/170-request-common.t
+++ b/t/170-request-common.t
@@ -16,7 +16,7 @@ subtest {
             content-type => 'multipart/form-data; boundary=XxYyZ'
         );
         todo("issue with line endings on travis");
-        is $req.Str.encode, slurp("t/dat/multipart-1.dat", :bin);
+        is-deeply $req.Str.encode, slurp("t/dat/multipart-1.dat", :bin);
     }, 'uri';
 }, 'POST(multi-part)';
 
@@ -111,4 +111,3 @@ subtest {
 }, 'PATCH';
 
 done-testing;
-


### PR DESCRIPTION
The new hash randomization in Rakudo 2018.05 causes some tests to fail. Change to use is-deeply() instead of is(). Fixes issue #197 