### PR TITLE
Hash order was changed in the last release

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -44,7 +44,7 @@
     "HTTP::UserAgent": "lib/HTTP/UserAgent.pm6",
     "HTTP::UserAgent::Common": "lib/HTTP/UserAgent/Common.pm6"
   },
-  "version": "1.1.40",
+  "version": "1.1.41",
   "meta-version": "0",
   "authors": [
     "sergot"

--- a/lib/HTTP/Header.pm6
+++ b/lib/HTTP/Header.pm6
@@ -118,7 +118,7 @@ method clear() {
 
 # get header as string
 method Str($eol = "\n") {
-    @.fields.map({ "{$_.name}: {self.field($_.name)}$eol" }).flat.join;
+    @.fields.map({ "{$_.name}: {self.field($_.name)}$eol" }).flat.sort.join;
 }
 
 method parse($raw) {

--- a/t/040-request.t
+++ b/t/040-request.t
@@ -50,7 +50,7 @@ lives-ok { $r1.set-method: 'PUT' }, "set method";
 is $r1.method, 'PUT', 'set-method 1/1';
 
 # parse
-my $req = "GET /index HTTP/1.1\r\nHost: somesite\r\nAccept: test\r\n\r\nname=value&a=b\r\n";
+my $req = "GET /index HTTP/1.1\r\nAccept: test\r\nHost: somesite\r\n\r\nname=value&a=b\r\n"; # Remember to use alphabetical order
 $r1 = HTTP::Request.new.parse($req);
 
 is $r1.method, 'get'.uc, 'parse 1/6';

--- a/t/040-request.t
+++ b/t/040-request.t
@@ -66,7 +66,7 @@ subtest {
    is $r.method, 'GET', "right method";
    is $r.file, '/bar', "right file";
    is $r.field('Host'), 'foo.com', 'got right host';
-}, "positional construcutor";
+}, "positional constructor";
 
 subtest {
     subtest {


### PR DESCRIPTION
Now it's guaranteed to always be different. You have to return always sorted keys. Hope this fixes the problem with 2018.05