### PR TITLE
Fix incorrect test routine

### DIFF
--- a/t/040-request.t
+++ b/t/040-request.t
@@ -99,7 +99,7 @@ subtest {
         my $req = HTTP::Request.new(POST => 'http://127.0.0.1/', Host => '127.0.0.1', content-type => 'multipart/form-data; boundary=XxYyZ');
         lives-ok { $req.add-form-data({ foo => "b&r", x   => ['t/dat/foo.txt'], }) }, "add-form-data";
         todo("issue seen on travis regarding line endings");
-        is $req.Str.encode, slurp("t/dat/multipart-1.dat", :bin);
+        is-deeply $req.Str.encode, slurp("t/dat/multipart-1.dat", :bin);
     }, 'multipart implied by existing content-type';
     subtest {
         my $req = HTTP::Request.new(POST => 'http://127.0.0.1/');


### PR DESCRIPTION
`is` tests string equivalency and Blobs can't be `.Str`ed willy-nilly.

Currently, the use of `is` is causing a crash of a TODOed test, when the routine attempts to stringify the Blobs for the diagnostic message ( https://github.com/sergot/http-useragent/issues/199 )