### PR TITLE
Kludge ordering of headers

### DIFF
--- a/lib/HTTP/Header.pm6
+++ b/lib/HTTP/Header.pm6
@@ -53,8 +53,8 @@ our class HTTP::Header::Actions {
 method new(*%fields) {
     my @fields;
 
-    for %fields.kv -> $k, $v {
-        @fields.push: HTTP::Header::Field.new(:name($k), :values($v.list));
+    for %fields.sort {
+        @fields.push: HTTP::Header::Field.new(:name(.key), :values(.value.list));
     }
 
     self.bless(:@fields);
@@ -64,7 +64,7 @@ proto method field(|c) { * }
 
 # set fields
 multi method field(*%fields) {
-    for %fields.kv -> $k, $v {
+    for %fields.sort -> (:key($k), :value($v)) {
         my $f = HTTP::Header::Field.new(:name($k), :values($v.list));
         if @.fields.first({ .name.lc eq $k.lc }) {
             @.fields[@.fields.first({ .name.lc eq $k.lc }, :k)] = $f;
@@ -81,7 +81,7 @@ multi method field($field) {
 
 # initialize fields
 method init-field(*%fields) {
-    for %fields.kv -> $k, $v {
+    for %fields.sort -> (:key($k), :value($v)) {
         if not @.fields.grep({ .name.lc eq $k.lc }) {
             @.fields.push: HTTP::Header::Field.new(:name($k), :values($v.list));
         }
@@ -90,7 +90,7 @@ method init-field(*%fields) {
 
 # add value to existing fields
 method push-field(*%fields) {
-    for %fields.kv -> $k, $v {
+    for %fields.sort -> (:key($k), :value($v)) {
         @.fields.first({ .name.lc eq $k.lc }).values.append: $v.list;
     }
 }

--- a/lib/HTTP/Request.pm6
+++ b/lib/HTTP/Request.pm6
@@ -37,7 +37,7 @@ multi method new(Bool :$bin, *%args) {
         }
 
         my $header = HTTP::Header.new(|%fields);
-    
+
         $method //= 'GET';
 
         self.new($method, $uri, $header, :$bin);
@@ -144,11 +144,11 @@ multi method add-content(Str $content) {
 proto method add-form-data(|c) { * }
 
 multi method add-form-data(:$multipart, *%data) {
-    self.add-form-data(%data.Array, :$multipart);
+    self.add-form-data(%data.sort.Array, :$multipart);
 }
 
 multi method add-form-data(%data, :$multipart) {
-    self.add-form-data(%data.Array, :$multipart);
+    self.add-form-data(%data.sort.Array, :$multipart);
 }
 
 multi method add-form-data(Array $data, :$multipart) {
@@ -391,7 +391,7 @@ inserted, the second (optional) an alternative name to be used in the
 content disposition header and the third an optional Array of Pair that
 will provide addtional header lines for the part.
 
-    
+
 =head2 method Str
 
     method Str returns Str;

--- a/t/040-request.t
+++ b/t/040-request.t
@@ -99,7 +99,7 @@ subtest {
         my $req = HTTP::Request.new(POST => 'http://127.0.0.1/', Host => '127.0.0.1', content-type => 'multipart/form-data; boundary=XxYyZ');
         lives-ok { $req.add-form-data({ foo => "b&r", x   => ['t/dat/foo.txt'], }) }, "add-form-data";
         todo("issue seen on travis regarding line endings");
-        is $req.Str.encode, slurp("t/dat/multipart-1.dat", :bin);
+        is-deeply Buf[uint8].new($req.Str.encode), slurp("t/dat/multipart-1.dat", :bin);
     }, 'multipart implied by existing content-type';
     subtest {
         my $req = HTTP::Request.new(POST => 'http://127.0.0.1/');

--- a/t/dat/multipart-1.dat
+++ b/t/dat/multipart-1.dat
@@ -4,14 +4,14 @@ Content-Type: multipart/form-data; boundary=XxYyZ
 Content-Length: 190
 
 --XxYyZ
+Content-Disposition: form-data; name="foo"
+
+b&r
+--XxYyZ
 Content-Disposition: form-data; name="x"; filename="foo.txt"
 Content-Type: application/octet-stream
 
 bar
 
---XxYyZ
-Content-Disposition: form-data; name="foo"
-
-b&r
 --XxYyZ--
 


### PR DESCRIPTION
This provides what I'd call a temporary fix, to unbust the tests and get the Rakudo release going.

The proper fix would require re-designing portions of the module, including user-facing methods that currently use hashes to pass data for which maintained order is desired.

-----------------------------------

Fixes https://github.com/rakudo/rakudo/issues/1880 Fixes #197 Fixes #199 Kludges #201
Fixes newly failing tests due to hash ordering now being
randomized in Perl 6, to prevent potential DoS attacks.

The module's design uses hashes to pass data for which ordering
is desired, but not required. So the proper fix would be a
larg-ish redesign that preserves the ordering of this data.

The fix simply sorts the data by keys, destroying original order,
but preserving *an* order, so that, for example, tests receive
predictable output.

Two pieces are affected:
1) Order of HTTP headers[^1]: The RFC says[^2] order doesn't
    matter, but there's some user demand[^3] for preserving the
    ordering for third party systems.
2) Order of Multi-Part form data: the HTML spec says[^4] the order
    of the parts represents the order the elements appear in the
    HTML. Looking at the .add-form-data method, I see they're passed
    via a hash, so order information is not available to the module
    from the very start and a differnt interface would be needed to
    make it available.

[1] https://github.com/sergot/http-useragent/issues/201
[2] https://tools.ietf.org/html/rfc2616#section-4.2
[3] https://github.com/sergot/http-useragent/pull/200#issuecomment-393671547
[4] https://www.w3.org/TR/html4/interact/forms.html#h-17.13.4