### PR TITLE
Fix issue #270: UserAgent.get crashes for binary data in debug mode.

### DIFF
--- a/lib/HTTP/Message.pm6
+++ b/lib/HTTP/Message.pm6
@@ -231,7 +231,7 @@ method Str($eol = "\n", :$debug, Bool :$bin) {
         $s ~=  $.content ~ $eol if $.content and !$debug;
     }
     if $.content and $debug {
-        if $bin {
+        if $bin || self.is-binary {
             $s ~= $eol ~ "=Content size : " ~ $.content.elems ~ " bytes ";
             $s ~= "$eol ** Not showing binary content ** $eol";
         }

--- a/t/270-issue-212.t
+++ b/t/270-issue-212.t
@@ -1,0 +1,10 @@
+use v6;
+use Test;
+use HTTP::UserAgent;
+
+plan 1;
+
+if %*ENV<NETWORK_TESTING> {
+    my $ua = HTTP::UserAgent.new(:debug);
+    lives-ok { $ua.get("http://httpbin.org/image/png") };
+}


### PR DESCRIPTION
Message.Str has to respect both :$bin and self.is-binary while deciding how to represent the data inside.