### PR TITLE
Fix issue #219 - form-urlencoded escaping

### DIFF
--- a/lib/HTTP/Request.pm6
+++ b/lib/HTTP/Request.pm6
@@ -166,11 +166,14 @@ multi method add-form-data(Array $data, :$multipart) {
         }
     };
 
+    sub form-escape(Str $s) {
+        uri-escape($s).subst(:g, '%20', '+').subst(:g, '%2A', '*');
+    }
     given $ct {
         when 'application/x-www-form-urlencoded' {
             my @parts;
             for @$data {
-                @parts.push: uri-escape(.key) ~ "=" ~ uri-escape(.value);
+                @parts.push: form-escape(.key) ~ "=" ~ form-escape(.value);
             }
             self.content = @parts.join("&").encode;
             self.header.field(Content-Length => self.content.bytes.Str);

--- a/t/041-form-urlencoded.t
+++ b/t/041-form-urlencoded.t
@@ -1,0 +1,40 @@
+use HTTP::Request;
+use Test;
+
+use URI;
+
+plan 3;
+
+# ref: https://url.spec.whatwg.org/#concept-urlencoded-serializer
+subtest {
+    my $req = HTTP::Request.new(POST => URI.new('http://127.0.0.1/'));
+    lives-ok { $req.add-form-data({ fO0159 => 'safe-*._', }) }, "add-form-data";
+    is $req.method, 'POST';
+    is $req.header.field('content-type'), 'application/x-www-form-urlencoded';
+    is $req.header.field('content-length'), '15';
+    is $req.content.decode, 'fO0159=safe-*._';
+}, 'urlencoded byte serializer - safe characters';
+subtest {
+    my $req = HTTP::Request.new(POST => URI.new('http://127.0.0.1/'));
+    lives-ok { $req.add-form-data({ 'foo bar' => '+ +', }) }, "add-form-data";
+    is $req.method, 'POST';
+    is $req.header.field('content-type'), 'application/x-www-form-urlencoded';
+    is $req.header.field('content-length'), '15';
+    is $req.content.decode, 'foo+bar=%2B+%2B';
+}, 'urlencoded byte serializer - spaces';
+subtest {
+    my $req = HTTP::Request.new(POST => URI.new('http://127.0.0.1/'));
+    lives-ok {
+        $req.add-form-data(
+            {
+                url => 'http://example.com/bar?user=baz&pass=xyzzy#"foo"',
+            }
+        )
+    }, "add-form-data";
+    is $req.method, 'POST';
+    is $req.header.field('content-type'), 'application/x-www-form-urlencoded';
+    is $req.header.field('content-length'), '74';
+    is $req.content.decode,
+      'url='
+      ~ 'http%3A%2F%2Fexample.com%2Fbar%3Fuser%3Dbaz%26pass%3Dxyzzy%23%22foo%22';
+}, 'urlencoded byte serializer - unsafe characters';


### PR DESCRIPTION
In t/041-form-urlencoded.t
    Add regression test
In lib/HTTP/Request.pm6
    Adjust escaping of form-urlencoded parts to conform with:
https://url.spec.whatwg.org/#concept-urlencoded-byte-serializer