### PR TITLE
Applied suggestions from #230

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -44,7 +44,7 @@
     "HTTP::UserAgent": "lib/HTTP/UserAgent.pm6",
     "HTTP::UserAgent::Common": "lib/HTTP/UserAgent/Common.pm6"
   },
-  "version": "1.1.48",
+  "version": "1.1.49",
   "meta-version": "0",
   "authors": [
     "sergot"

--- a/t/150-issue-64.t
+++ b/t/150-issue-64.t
@@ -15,11 +15,7 @@ unless %*ENV<NETWORK_TESTING> {
 
 my $purl = 'http://purl.org/dc/elements/1.1/';
 
-my $ua = HTTP::UserAgent.new(
-    useragent =>
-        'Mozilla/5.0 (X11; Fedora-Pheix; Linux x86_64; rv:72.0) ' ~
-        'Gecko/20100101 Firefox/72.0'
-);
+my $ua = HTTP::UserAgent.new( useragent => "firefox_linux" );
 
 my HTTP::Response $resp;
 

--- a/t/150-issue-64.t
+++ b/t/150-issue-64.t
@@ -15,7 +15,11 @@ unless %*ENV<NETWORK_TESTING> {
 
 my $purl = 'http://purl.org/dc/elements/1.1/';
 
-my $ua = HTTP::UserAgent.new;
+my $ua = HTTP::UserAgent.new(
+    useragent =>
+        'Mozilla/5.0 (X11; Fedora-Pheix; Linux x86_64; rv:72.0) ' ~
+        'Gecko/20100101 Firefox/72.0'
+);
 
 my HTTP::Response $resp;
 


### PR DESCRIPTION
> Unless you want to pass the specific UA then you could use firefox_linux and it will look up something appropriate in the get-ua routine.

Test `./t/150-issue-64.t` is updated with @jonathanstowe  suggestions from #230.