### PR TITLE
Connection error 404 Bad Request via proxy

### DIFF
--- a/lib/HTTP/Request.pm6
+++ b/lib/HTTP/Request.pm6
@@ -285,7 +285,7 @@ method make-boundary(int $size=10) {
 
 
 method Str (:$debug, Bool :$bin) {
-    $.file = '/' ~ $.file unless $.file.starts-with: '/';
+    $.file ~~ s/^([https?':/']?)['/']?/$0\//;
     my $s = "$.method $.file $.protocol";
     $s ~= $CRLF ~ callwith($CRLF, :debug($debug), :$bin);
 }


### PR DESCRIPTION
Everytime I tried to conect via a proxy, I was getting a `400 Bad
Request` error. Debugging the problem, I found out that the `Str` method
of `HTTP::Request` was ignoring the case where the `$.file` field was a
copy of the `$.url` field and, because of it, started with `"http"`. The
connection was asking my proxy for a `GET /http://etcetc`