### PR TITLE
Decode header as ISO-8859-1

### DIFF
--- a/lib/HTTP/Response.pm6
+++ b/lib/HTTP/Response.pm6
@@ -20,7 +20,9 @@ proto method new(|c) { * }
 
 # This candidate makes it easier to test weird responses
 multi method new(Blob $header-chunk) {
-    my ( $rl, $header ) = $header-chunk.decode('ascii').split(/\r?\n/, 2);
+    # See https://tools.ietf.org/html/rfc7230#section-3.2.4
+    my ( $rl, $header ) = $header-chunk.decode('ISO-8859-1').split(/\r?\n/, 2);
+
     if not $rl {
         X::HTTP::NoResponse.new.throw;
     }

--- a/t/050-response.t
+++ b/t/050-response.t
@@ -6,7 +6,7 @@ use Test;
 
 use HTTP::Response;
 
-plan 27;
+plan 28;
 
 # new
 my $r = HTTP::Response.new(200, a => 'a');
@@ -69,12 +69,17 @@ subtest {
     my $r;
     throws-like { $r = HTTP::Response.new(Buf.new) }, X::HTTP::NoResponse, "create with an empty buf";
     my $garbage = Buf.new(('a' .. 'z', 'A' .. 'Z').pick(20).map({$_.ords}).flat);
-    lives-ok { 
-        $r = HTTP::Response.new($garbage); 
+    lives-ok {
+        $r = HTTP::Response.new($garbage);
     }, "create with garbage";
     is $r.code, 500, "and got a 500 response";
 
 }, "failure modes";
 
+subtest {
+    my $res = HTTP::Response.new: "HTTP/1.1 200 OK\r\nX-Duck: 🦆\r\n".encode;
+    is $res.status-line, '200 OK', 'Can parse responses with non-ASCII header values';
+    is $res.header.field('X-Duck'), "ð\x[9F]¦\x[86]", 'Header value decoded as ISO-8859-1';
+}, 'Non-ASCII header values'
 
 # vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
Before this change, requests to servers that send UTF-8 data (or any
non-ASCII data) as a header value (such as the `x-duck` that
http://icanhazip.com sets to 🦆) would be unparseable, and die with

> Will not decode invalid ASCII (code point (-16) < 0 found)

error.

Although servers _shouldn't_ be sending ducks in HTTP/1.1 headers,
clients also _shouldn't_ die when trying to parse those responses.

On this, [RFC 7230 § 3.2.4] states:

> Historically, HTTP has allowed field content with text in the
> ISO-8859-1 charset [ISO-8859-1], supporting other charsets only
> through use of [RFC2047] encoding.  In practice, most HTTP header
> field values use only a subset of the US-ASCII charset [USASCII].
> Newly defined header fields SHOULD limit their field values to
> US-ASCII octets.  A recipient SHOULD treat other octets in field
> content (obs-text) as opaque data.

It is not clear what the spec suggests clients should do regarding
this 'opaque data', but the solution in this patch means that
responses can be parsed, and users that _do_ want to recover whatever
opaque data was sent in a header can do so by re-encoding the header
value and decoding in whatever way is appropriate.

The change in this case is a little broader than ideal, since it
interprets the entire header chunk (including the status line and
all headers) as ISO-8859-1. Mitigations for this could be put in
place if needed, but some more involved refactoring would likely be
required.

For what it's worth, this solution will make HTTP::UserAgent produce
similar results to Cro::HTTP::Client, and HTTP::Tiny. Curl-based Raku
libraries will, on the other hand, decode the duck as UTF-8 which,
although funnier, is arguably incorrect.

[RFC 7230 § 3.2.4]: https://tools.ietf.org/html/rfc7230#section-3.2.4

Fixes #236