### PR TITLE
request - response

### DIFF
--- a/lib/HTTP/Message.rakumod
+++ b/lib/HTTP/Message.rakumod
@@ -238,7 +238,16 @@ method Str($eol = "\n", :$debug, Bool :$bin) {
         # https://datatracker.ietf.org/doc/html/rfc2616#section-7.2
         # https://datatracker.ietf.org/doc/html/rfc2616#section-14.41
         
+        # TODO : replace following line with code following it
         $s ~=  $.content ~ $eol if $.content and !$debug;
+        # TODO : uncomment following code for final implementation
+#         if self.is-chunked {
+#             $s ~= $.content ~ $eol;
+#         }
+#         else {
+#             $s ~= $.content;
+#             self.header.field(Content-Length => self.content.encode.bytes.Str);
+#         }
     }
     if $.content and $debug {
         if $bin || self.is-binary {

--- a/lib/HTTP/Message.rakumod
+++ b/lib/HTTP/Message.rakumod
@@ -103,6 +103,18 @@ method is-text(--> Bool:D) {
 
 method is-binary(--> Bool:D) { !self.is-text }
 
+method is-chunked(--> Bool:D) {
+# 	multiple transfer-codings can be listed; chunked should be last
+# 	https://datatracker.ietf.org/doc/html/rfc2616#section-14.41
+# 	https://datatracker.ietf.org/doc/html/rfc7230#section-4
+	
+	# TODO : uncomment after confirming testcase
+#     my $enc = self.field('Transfer-Encoding');
+#     $enc and $enc.trim.lc.ends-with: 'chunked'
+	# TODO : remove after implementing
+	...
+}
+
 method content-encoding() {
     $!header.field('Content-Encoding');
 }
@@ -221,6 +233,11 @@ method Str($eol = "\n", :$debug, Bool :$bin) {
     
     # The :bin will be passed from the H::UA
     if not $bin {
+        # do not append eol unless chunked
+        # https://datatracker.ietf.org/doc/html/rfc2616#section-4.3
+        # https://datatracker.ietf.org/doc/html/rfc2616#section-7.2
+        # https://datatracker.ietf.org/doc/html/rfc2616#section-14.41
+        
         $s ~=  $.content ~ $eol if $.content and !$debug;
     }
     if $.content and $debug {

--- a/lib/HTTP/Message.rakumod
+++ b/lib/HTTP/Message.rakumod
@@ -294,8 +294,10 @@ method chunked-content {
 
 method Str($eol = "\n", :$debug, Bool :$bin) {
     my constant $max_size = 300;
-    self.field(Content-Length => $!content.encode.bytes.Str)
-        unless self.is-chunked;
+    # TODO : reference relevant section of relevant RFC
+    # TODO : need to consider Str vs Buf length ?
+    self.field(Content-Length => ( $!content.?encode or $!content ).bytes.Str)
+        if $!content and not self.field: 'Transfer-Encoding';
     my $s = $.header.Str($eol);
     $s ~= $eol if $.content;
     
@@ -309,7 +311,8 @@ method Str($eol = "\n", :$debug, Bool :$bin) {
 #         # TODO : replace following line with code following it
 #         $s ~=  $.content ~ $eol if $.content and !$debug;
         # TODO : uncomment following code for final implementation
-        $s ~= self.is-chunked ?? self.chunked-content !! $!content;
+        $s ~= self.is-chunked ?? self.chunked-content !! $!content
+            if $!content;
     }
     if $.content and $debug {
         if $bin || self.is-binary {

--- a/lib/HTTP/Message.rakumod
+++ b/lib/HTTP/Message.rakumod
@@ -6,6 +6,7 @@ use Encode;
 
 has HTTP::Header $.header = HTTP::Header.new;
 has $.content is rw;
+has Int:D $.chunk-size is rw = 4096;
 
 has $.protocol is rw = 'HTTP/1.1';
 
@@ -103,16 +104,43 @@ method is-text(--> Bool:D) {
 
 method is-binary(--> Bool:D) { !self.is-text }
 
+# TODO : proposed method to set request to chunked and specify the chunk size
+# TODO : how to keep synced with Transfer-Encoding if user adds chunked there ?
+# TODO : specify in UserAgent ?
+# set size 0 for non-chunked
+method set-chunked(Int:D $size = 4096) {
+	if $size {
+		$!chunk-size = $size;
+		self.push-field: Transfer-Encoding => 'chunked'
+			unless self.is-chunked;
+	}
+	else {
+		# make non-chunked
+		$!chunk-size = 0;
+		if self.is-chunked {
+			my Str $te = .Str with self.field: 'Transfer-Encoding';
+			$te ~~ s/[\s*\,\s*]?chunked\s*$//;
+			$te .=trim;
+			if $te {
+				self.field: 'Transfer-Encoding', $te;
+			}
+			else {
+				self.remove-field: 'Transfer-Encoding';
+			}
+		}
+	}
+}
+
 method is-chunked(--> Bool:D) {
 # 	multiple transfer-codings can be listed; chunked should be last
 # 	https://datatracker.ietf.org/doc/html/rfc2616#section-14.41
 # 	https://datatracker.ietf.org/doc/html/rfc7230#section-4
 	
 	# TODO : uncomment after confirming testcase
-#     my $enc = self.field('Transfer-Encoding');
-#     $enc and $enc.trim.lc.ends-with: 'chunked'
-	# TODO : remove after implementing
-	...
+    my $enc = self.field('Transfer-Encoding');
+    so $enc and $enc.Str.trim.lc.ends-with: 'chunked'
+# 	# TODO : remove after implementing
+# 	...
 }
 
 method content-encoding() {
@@ -170,7 +198,6 @@ method decoded-content(:$bin) {
 
     $decoded_content
 }
-
 multi method field(Str $f) {
     $.header.field($f)
 }
@@ -203,7 +230,8 @@ method parse($raw_message) {
     else {               # is a response
         $.protocol = $first;
     }
-
+	
+	my Bool:D $tec = False;
     loop {
         last until @lines;
 
@@ -211,12 +239,21 @@ method parse($raw_message) {
         if $line {
             my ($k, $v) = $line.split(/\:\s*/, 2);
             if $k and $v {
+                $tec = True if $k eq 'Transfer-Encoding'
+                    and $v.trim.lc.ends-with: 'chunked';
                 if $.header.field($k) {
                     $.header.push-field: |($k => $v.split(',')>>.trim);
                 } else {
                     $.header.field: |($k => $v.split(',')>>.trim);
                 }
             }
+        } elsif $tec {
+            # chunked, add zero-length Str to end as size 0 chunk
+            @lines.push: '' if +@lines % 2;
+            $!content = join '',
+                grep *,
+                @lines.map: -> $s, $d { $s ~~ /^\d/ ?? $d !! '' };
+            last;
         } else {
             $.content = @lines.grep({ $_ }).join("\n");
             last;
@@ -226,8 +263,39 @@ method parse($raw_message) {
     self
 }
 
+# proposed method for partitioning into chunks
+method chunked-content {
+	# TODO : how to handle call when non-chunked ?
+	return unless self.is-chunked and $!chunk-size;
+	# TODO : handle binary
+	unless self.is-binary {
+		# TODO : consider encoding ?
+		my Str:D @c = $!content.comb: $!chunk-size;
+		my Str:D $s = join $CRLF, '0', $CRLF; # last chunk
+		given @c.elems {
+			when 0 {
+				# just last chunk, nothing to do
+			}
+			when 1..* {
+				$s = join $CRLF,
+						@c[*-1].chars.base(16),
+						@c[*-1],
+						$s;
+				proceed;
+			}
+			when 2..* {
+				my Str $cs = $!chunk-size.base: 16;
+				$s = join $CRLF, ( ( $cs xx * ) Z @c[0..*-2] ).flat, $s;
+			}
+		}
+		$s;
+	}
+}
+
 method Str($eol = "\n", :$debug, Bool :$bin) {
     my constant $max_size = 300;
+    self.field(Content-Length => $!content.encode.bytes.Str)
+        unless self.is-chunked;
     my $s = $.header.Str($eol);
     $s ~= $eol if $.content;
     
@@ -238,16 +306,10 @@ method Str($eol = "\n", :$debug, Bool :$bin) {
         # https://datatracker.ietf.org/doc/html/rfc2616#section-7.2
         # https://datatracker.ietf.org/doc/html/rfc2616#section-14.41
         
-        # TODO : replace following line with code following it
-        $s ~=  $.content ~ $eol if $.content and !$debug;
+#         # TODO : replace following line with code following it
+#         $s ~=  $.content ~ $eol if $.content and !$debug;
         # TODO : uncomment following code for final implementation
-#         if self.is-chunked {
-#             $s ~= $.content ~ $eol;
-#         }
-#         else {
-#             $s ~= $.content;
-#             self.header.field(Content-Length => self.content.encode.bytes.Str);
-#         }
+        $s ~= self.is-chunked ?? self.chunked-content !! $!content;
     }
     if $.content and $debug {
         if $bin || self.is-binary {

--- a/lib/HTTP/Request.rakumod
+++ b/lib/HTTP/Request.rakumod
@@ -116,10 +116,20 @@ method add-cookies($cookies) {
     $cookies.add-cookie-header(self) if $cookies.cookies;
 }
 
+# TODO : proposed method to set request to chunked and specify the chunk size
+# TODO : need to negotiate with server ?
+#   automatically use chunked if server supports ?
+# TODO : specify in UserAgent ?
+method set-chunked(Int $size? = 4096) {
+	
+}
+
 proto method add-content(|) {*}
 
 multi method add-content(Str:D $content) {
     self.content ~= $content;
+    # TODO : move calculation to end of Message ( Message.Str method )
+    #   and only if not chunked
     self.header.field(Content-Length => self.content.encode.bytes.Str);
 }
 

--- a/lib/HTTP/Request.rakumod
+++ b/lib/HTTP/Request.rakumod
@@ -116,21 +116,14 @@ method add-cookies($cookies) {
     $cookies.add-cookie-header(self) if $cookies.cookies;
 }
 
-# TODO : proposed method to set request to chunked and specify the chunk size
-# TODO : need to negotiate with server ?
-#   automatically use chunked if server supports ?
-# TODO : specify in UserAgent ?
-method set-chunked(Int $size? = 4096) {
-	
-}
-
 proto method add-content(|) {*}
 
 multi method add-content(Str:D $content) {
     self.content ~= $content;
     # TODO : move calculation to end of Message ( Message.Str method )
     #   and only if not chunked
-    self.header.field(Content-Length => self.content.encode.bytes.Str);
+#     self.header.field(Content-Length => self.content.encode.bytes.Str)
+#         unless self.is-chunked;
 }
 
 proto method add-form-data(|) {*}
@@ -143,6 +136,7 @@ multi method add-form-data(%data, :$multipart) {
     self.add-form-data(%data.sort.Array, :$multipart);
 }
 
+# TODO : verify presence of Content-Length
 multi method add-form-data(Array $data, :$multipart) {
     my $ct = do {
         my $f = self.header.field('Content-Type');

--- a/lib/HTTP/Response.rakumod
+++ b/lib/HTTP/Response.rakumod
@@ -56,15 +56,10 @@ method has-content(--> Bool:D) {
 }
 
 # TODO : remove once Message.is-chunked is implemented
-method is-chunked(--> Bool:D) {
-# multiple transfer-codings can be listed; chunked should be last
-# https://datatracker.ietf.org/doc/html/rfc2616#section-14.41
-# https://datatracker.ietf.org/doc/html/rfc7230#section-4
-#     my $enc = self.field('Transfer-Encoding');
-#     $enc and $enc.trim.lc.ends-with: 'chunked'
-   self.field('Transfer-Encoding')
-     && self.field('Transfer-Encoding') eq 'chunked'
-}
+# method is-chunked(--> Bool:D) {
+#    self.field('Transfer-Encoding')
+#      && self.field('Transfer-Encoding') eq 'chunked'
+# }
 
 method set-code(Int:D $code) {
     $!code = $code;

--- a/lib/HTTP/Response.rakumod
+++ b/lib/HTTP/Response.rakumod
@@ -56,6 +56,11 @@ method has-content(--> Bool:D) {
 }
 
 method is-chunked(--> Bool:D) {
+# multiple transfer-codings can be listed; chunked should be last
+# https://datatracker.ietf.org/doc/html/rfc2616#section-14.41
+# https://datatracker.ietf.org/doc/html/rfc7230#section-4
+#     my $enc = self.field('Transfer-Encoding');
+#     $enc and $enc.trim.lc.ends-with: 'chunked'
    self.field('Transfer-Encoding')
      && self.field('Transfer-Encoding') eq 'chunked'
 }

--- a/lib/HTTP/Response.rakumod
+++ b/lib/HTTP/Response.rakumod
@@ -55,6 +55,7 @@ method has-content(--> Bool:D) {
     (204, 304).grep({ $!code eq $_ }) ?? False !! True;
 }
 
+# TODO : remove once Message.is-chunked is implemented
 method is-chunked(--> Bool:D) {
 # multiple transfer-codings can be listed; chunked should be last
 # https://datatracker.ietf.org/doc/html/rfc2616#section-14.41

--- a/lib/HTTP/UserAgent.rakumod
+++ b/lib/HTTP/UserAgent.rakumod
@@ -278,7 +278,6 @@ method get-response(HTTP::Request $request, Connection $conn, Bool :$bin --> HTT
     # Header can be longer than one chunk
     while my $t = $conn.recv( :bin ) {
         $first-chunk ~= $t;
-say 'UserAgent 279 first chunk ', $t.decode: 'iso-8859-1';
         # Find the header/body separator in the chunk, which means
         # we can parse the header seperately and are  able to figure
         # out the correct encoding of the body.
@@ -298,16 +297,12 @@ say 'UserAgent 279 first chunk ', $t.decode: 'iso-8859-1';
         # didn't send it we're stuffed anyway
         $first-chunk;
     }
-say 'HEADER CHUNK ', $header-chunk;
-say 'response with header chunk UserAgent 300';
     my HTTP::Response $response = HTTP::Response.new($header-chunk);
     $response.request = $request;
-say 'request set UserAgent 303';
     if $response.has-content {
         if !$msg-body-pos.defined {
             X::HTTP::Internal.new(rc => 500, reason => "server returned no data").throw;
         }
-say 'msg-body-pos check UserAgent 308';
 
         my $content = $first-chunk.subbuf($msg-body-pos);
         # Turn the inner exceptions to ours
@@ -320,15 +315,12 @@ say 'msg-body-pos check UserAgent 308';
         # We also need to handle 'Transfer-Encoding: chunked', which means
         # that we request more chunks and assemble the response body.
         if $response.is-chunked {
-say 'getting chunked content UserAgent 321';
             $content = self.get-chunked-content($conn, $content);
         }
         elsif $response.content-length -> $content-length is copy {
-say 'getting content by length UserAgent 325';
             $content = self.get-content($conn, $content, $content-length);
         }
         else {
-say 'getting content fallback UserAgent 329';
             $content = self.get-content($conn, $content);
         }
 

--- a/lib/HTTP/UserAgent.rakumod
+++ b/lib/HTTP/UserAgent.rakumod
@@ -23,7 +23,9 @@ role Connection {
             self.print($request.Str(:bin));
             self.write($request.content);
         }
-        else {
+        elsif $request.method.Str eq 'POST' | 'PUT' {
+            self.print($request.Str);
+        } else {
             self.print($request.Str ~ "\r\n");
         }
     }
@@ -276,7 +278,7 @@ method get-response(HTTP::Request $request, Connection $conn, Bool :$bin --> HTT
     # Header can be longer than one chunk
     while my $t = $conn.recv( :bin ) {
         $first-chunk ~= $t;
-
+say 'UserAgent 279 first chunk ', $t.decode: 'iso-8859-1';
         # Find the header/body separator in the chunk, which means
         # we can parse the header seperately and are  able to figure
         # out the correct encoding of the body.
@@ -296,16 +298,16 @@ method get-response(HTTP::Request $request, Connection $conn, Bool :$bin --> HTT
         # didn't send it we're stuffed anyway
         $first-chunk;
     }
-
-
+say 'HEADER CHUNK ', $header-chunk;
+say 'response with header chunk UserAgent 300';
     my HTTP::Response $response = HTTP::Response.new($header-chunk);
     $response.request = $request;
-
+say 'request set UserAgent 303';
     if $response.has-content {
         if !$msg-body-pos.defined {
             X::HTTP::Internal.new(rc => 500, reason => "server returned no data").throw;
         }
-
+say 'msg-body-pos check UserAgent 308';
 
         my $content = $first-chunk.subbuf($msg-body-pos);
         # Turn the inner exceptions to ours
@@ -318,12 +320,15 @@ method get-response(HTTP::Request $request, Connection $conn, Bool :$bin --> HTT
         # We also need to handle 'Transfer-Encoding: chunked', which means
         # that we request more chunks and assemble the response body.
         if $response.is-chunked {
+say 'getting chunked content UserAgent 321';
             $content = self.get-chunked-content($conn, $content);
         }
         elsif $response.content-length -> $content-length is copy {
+say 'getting content by length UserAgent 325';
             $content = self.get-content($conn, $content, $content-length);
         }
         else {
+say 'getting content fallback UserAgent 329';
             $content = self.get-content($conn, $content);
         }
 

--- a/t/021-message-issue-226.rakutest
+++ b/t/021-message-issue-226.rakutest
@@ -1,0 +1,53 @@
+use Test;
+use HTTP::Message;
+
+plan 10;
+
+my constant $CRLF = "\r\n";
+
+# construct request - move to request 042-request-issue-226.rakutest
+# my $m = HTTP::Message.new:
+# 		'four',
+# 		Content-Type => 'text/plain',
+# 		Transfer-Encoding => 'chunked'
+# 		;
+
+my Str:D $expected = join $CRLF,
+	'POST site HTTP/1.1',           # request line
+	'Content-Type: text/plain',     # header
+	'Transfer-Encoding: chunked',   # header
+	'',     # end of header
+	'4',    # chunk size
+	'four', # chunk data
+	'',     # end of chunk
+	'0',    # last chunk
+	$CRLF,  # end of chunk body
+; # FIXME : does not test: trailer, chunk extension
+my $m = HTTP::Message.new.parse: $expected;
+
+isa-ok $m, HTTP::Request, 'detected correct message type';
+is $m.protocol, 'HTTP/1.1', 'protocol';
+is $m.field('Transfer-Encoding'), 'chunked', 'parsed header';
+is $m.content, 'four', 'parsed content';
+ok $m.is-chunked, 'chunked';
+ok $m.is-text, 'text';
+nok $m.is-binary, 'not binary data';
+is $m.Str($CRLF), $expected, 'chunked Str';
+
+# switch to non-chunked; use Content-Length
+$m.remove-field: 'Transfer-Encoding';
+
+# add-content
+$m.add-content: '-five';
+is $m.content, 'four-five', 'add-content';
+
+$expected = join $CRLF,
+	'POST site HTTP/1.1',           # request line
+	'Content-Length: 9',            # header
+	'Content-Type: text/plain',     # header
+	'',                             # end of header
+	'four-five',                    # content
+; # FIXME : does not test: trailer, chunk extension
+is $m.Str(), $expected, 'non-chunked Str';
+
+# vim: expandtab shiftwidth=4

--- a/t/021-message-issue-226.rakutest
+++ b/t/021-message-issue-226.rakutest
@@ -1,7 +1,10 @@
-use Test;
-use HTTP::Message;
+use lib 'lib';
 
-plan 10;
+use Test;
+use HTTP::Request;
+use HTTP::Response;
+
+plan 2;
 
 my constant $CRLF = "\r\n";
 
@@ -11,43 +14,84 @@ my constant $CRLF = "\r\n";
 # 		Content-Type => 'text/plain',
 # 		Transfer-Encoding => 'chunked'
 # 		;
+subtest {
+	plan 13;
+	my Str:D $expected = join $CRLF,
+		'POST /site HTTP/1.1',          # request line
+		'Content-Type: text/plain',     # header
+		'Transfer-Encoding: chunked',   # header
+		'',         # end of header
+		'6',        # chunk size
+		'- four',   # chunk data
+		'0',        # last chunk
+		$CRLF,      # end of chunk body
+	; # FIXME : does not test: trailer, chunk extension, binary
+	my HTTP::Request:D $m = HTTP::Request.new.parse: $expected;
+	
+	is $m.protocol, 'HTTP/1.1', 'protocol';
+	is $m.field('Transfer-Encoding'), 'chunked', 'parsed header';
+	is $m.content, '- four', 'parsed content';
+	ok $m.is-chunked, 'chunked';
+	ok $m.is-text, 'text';
+	nok $m.is-binary, 'not binary data';
+	$m.set-chunked;
+	ok $m.is-chunked, 'chunked after (implicitly) setting chunk size';
+	is $m.chunk-size, 4096, 'default chunk size';
+	is $m.Str, $expected, 'chunked Str';
+	
+	# add-content
+	$m.add-content: "\n- five";
+	is $m.content, "- four\n- five", 'add-content';
+	
+	$expected = join $CRLF,
+		'POST /site HTTP/1.1',          # request line
+		'Content-Type: text/plain',     # header
+		'Transfer-Encoding: chunked',   # header
+		'',     # end of header
+		'4',    # chunk size
+		'- fo', # chunk data
+		'4',    # chunk size
+		"ur\n-",# chunk data
+		'4',    # chunk size
+		' fiv', # chunk data
+		'1',    # final content chunk size
+		'e',    # final content chunk data
+		'0',    # last chunk
+		$CRLF,  # end of chunked body
+	; # FIXME : does not test: trailer, chunk extension, binary
+	$m.set-chunked: 4;
+	is $m.chunk-size, 4, 'chunk size set';
+	is $m.Str, $expected, 'chunked Str with multiple chunks';
+	
+	# switch to non-chunked; use Content-Length
+	# $m.remove-field: 'Transfer-Encoding';
+	$m.set-chunked: 0;
+	
+	$expected = join $CRLF,
+		'POST /site HTTP/1.1',          # request line
+		'Content-Type: text/plain',     # header
+		'Content-Length: 13',           # header
+		'',                             # end of header
+		"- four\n- five",                    # content
+	; # FIXME : does not test: trailer, chunk extension, binary
+	is $m.Str, $expected, 'non-chunked Str';
+}, 'chunked request';
 
-my Str:D $expected = join $CRLF,
-	'POST site HTTP/1.1',           # request line
-	'Content-Type: text/plain',     # header
-	'Transfer-Encoding: chunked',   # header
-	'',     # end of header
-	'4',    # chunk size
-	'four', # chunk data
-	'',     # end of chunk
-	'0',    # last chunk
-	$CRLF,  # end of chunk body
-; # FIXME : does not test: trailer, chunk extension
-my $m = HTTP::Message.new.parse: $expected;
 
-isa-ok $m, HTTP::Request, 'detected correct message type';
-is $m.protocol, 'HTTP/1.1', 'protocol';
-is $m.field('Transfer-Encoding'), 'chunked', 'parsed header';
-is $m.content, 'four', 'parsed content';
-ok $m.is-chunked, 'chunked';
-ok $m.is-text, 'text';
-nok $m.is-binary, 'not binary data';
-is $m.Str($CRLF), $expected, 'chunked Str';
 
-# switch to non-chunked; use Content-Length
-$m.remove-field: 'Transfer-Encoding';
-
-# add-content
-$m.add-content: '-five';
-is $m.content, 'four-five', 'add-content';
-
-$expected = join $CRLF,
-	'POST site HTTP/1.1',           # request line
-	'Content-Length: 9',            # header
-	'Content-Type: text/plain',     # header
-	'',                             # end of header
-	'four-five',                    # content
-; # FIXME : does not test: trailer, chunk extension
-is $m.Str(), $expected, 'non-chunked Str';
+subtest {
+	plan 5;
+	# parse
+	my Str:D $to_parse = "HTTP/1.1 200 OK\r\n"
+	          ~ "Content-Length: 3\r\n"
+	          ~ "\r\n"
+	          ~ "a\nb";
+	my HTTP::Response:D $m2 = HTTP::Response.new.parse($to_parse);
+	nok $m2.is-chunked, 'not chunked';
+	ok $m2.is-text, 'text';
+	nok $m2.is-binary, 'not binary';
+	is $m2.field('Content-Length'), '3', 'Content-Length';
+	is $m2.Str, $to_parse, 'non-chunked Str';
+}, 'non-chunked response';
 
 # vim: expandtab shiftwidth=4

--- a/t/021-message-issue-226.rakutest
+++ b/t/021-message-issue-226.rakutest
@@ -1,10 +1,8 @@
-use lib 'lib';
-
 use Test;
 use HTTP::Request;
 use HTTP::Response;
 
-plan 2;
+plan 3;
 
 my constant $CRLF = "\r\n";
 
@@ -92,6 +90,26 @@ subtest {
 	nok $m2.is-binary, 'not binary';
 	is $m2.field('Content-Length'), '3', 'Content-Length';
 	is $m2.Str, $to_parse, 'non-chunked Str';
-}, 'non-chunked response';
+}, 'parse non-chunked response';
+
+
+
+subtest {
+	plan 4;
+	# parse
+	my Str:D $to_parse = "HTTP/1.1 200 OK\r\n"
+	          ~ "Transfer-Encoding: chunked\r\n"
+	          ~ "\r\n"
+	          ~ "3\r\n"
+	          ~ "a\nb\r\n"
+	          ~ "0\r\n"
+	          ~ "\r\n"
+	          ;
+	my HTTP::Response:D $m2 = HTTP::Response.new.parse($to_parse);
+	ok $m2.is-chunked, 'chunked';
+	ok $m2.is-text, 'text';
+	nok $m2.is-binary, 'not binary';
+	is $m2.Str, $to_parse, 'chunked Str';
+}, 'parse chunked response';
 
 # vim: expandtab shiftwidth=4

--- a/t/042-request-issue-226.rakutest
+++ b/t/042-request-issue-226.rakutest
@@ -1,0 +1,49 @@
+use lib 'lib';
+
+use Test;
+use URI;
+use HTTP::Request;
+
+plan 2;
+
+my constant $CRLF = "\r\n";
+
+my Str:D $host  = 'dne.site';
+my Str:D $resource = 'resource';
+my $url = "http://$host/$resource";
+
+my Str:D $expected = join $CRLF,
+	"POST /$resource HTTP/1.1",                 # request line
+	'Content-Type: text/plain; charset=UTF-8',  # header
+	'Transfer-Encoding: chunked',               # header
+	"Host: $host",                              # header
+	'',                 # end of header
+	'D',                # chunk size
+	"- four\n- five",   # chunk data
+	'0',                # last chunk
+	$CRLF,              # end of chunk body
+; # FIXME : does not test: trailer, chunk extension, binary
+
+my HTTP::Request $r =
+	HTTP::Request.new:
+			POST => $url,
+			Content-Type => 'text/plain; charset=UTF-8',
+			Transfer-Encoding => 'chunked';
+$r.add-content: "- four\n- five";
+is $r.Str, $expected, 'build chunked post';
+
+$expected = join $CRLF,
+    "POST /$resource HTTP/1.1",                 # request line
+    "Host: $host",                              # header
+    'Content-Length: 13',                       # header
+    '',                 # end of header
+    "- four\n- five",   # content
+; # FIXME : does not test: trailer, chunk extension, binary
+
+$r =
+    HTTP::Request.new:
+            POST => $url;
+$r.add-content: "- four\n- five";
+is $r.Str, $expected, 'build non-chunked post';
+
+# vim: expandtab shiftwidth=4

--- a/t/042-request-issue-226.rakutest
+++ b/t/042-request-issue-226.rakutest
@@ -1,5 +1,3 @@
-use lib 'lib';
-
 use Test;
 use URI;
 use HTTP::Request;

--- a/t/051-response-issue-226.rakutest
+++ b/t/051-response-issue-226.rakutest
@@ -1,0 +1,49 @@
+use Test;
+use HTTP::Response;
+
+plan 2;
+
+my constant $CRLF = "\r\n";
+
+subtest {
+	plan 5;
+	my $r = HTTP::Response.new;
+	my Str:D $expected = join $CRLF,
+		'HTTP/1.1 200 OK',              # status line
+		'Content-Type: text/plain',     # header
+	    'Transfer-Encoding: chunked',   # header
+	    '',         # end header
+	    '7',        # chunk size
+	    'content',  # chunk data
+	    '0',        # last chunk
+	    $CRLF       # end chunk body
+		;
+	$r.field: Content-Type => 'text/plain', Transfer-Encoding => 'chunked';
+	$r.add-content: 'content';
+	ok $r.is-text, 'is text';
+	nok $r.is-binary, 'not binary';
+	ok $r.is-chunked, 'chunked';
+	is $r.content, 'content', 'content';
+	is $r.Str, $expected, 'Str';
+}, 'build chunked Str';
+
+subtest {
+	plan 5;
+	my $r = HTTP::Response.new;
+	my Str:D $expected = join $CRLF,
+		'HTTP/1.1 200 OK',              # status line
+	    'Content-Length: 7',            # header
+		'Content-Type: text/plain',     # header
+	    '',         # end header
+	    'content',  # content
+		;
+	$r.field: Content-Type => 'text/plain', Content-Length => '7';
+	$r.add-content: 'content';
+	ok $r.is-text, 'is text';
+	nok $r.is-binary, 'not binary';
+	nok $r.is-chunked, 'not chunked';
+	is $r.content, 'content', 'content';
+	is $r.Str, $expected, 'Str';
+}, 'build non-chunked Str';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Resolves raku-community-modules/HTTP-UserAgent#226

Draft for reviewing eol handling changes to HTTP::Message and both subclasses.

Some things to note:
- most work draws from RFC2616 - need to check current RFCs
- [020-message.rakutest Str 1/2 testcase](https://github.com/zjmarlow/HTTP-UserAgent/blob/d6c4e7760f39265f8cdebe0be9ffce7085257221/t/020-message.rakutest#L41) currently fails due to Content-Length now being auto-calculated / included
- [020-message.rakutest Str 2/2 testcase](https://github.com/zjmarlow/HTTP-UserAgent/blob/d6c4e7760f39265f8cdebe0be9ffce7085257221/t/020-message.rakutest#L42) currently fails due to Content-Length now being auto-calculated / included
- [040-request.rakutest parse 6/6 testcase](https://github.com/zjmarlow/HTTP-UserAgent/blob/d6c4e7760f39265f8cdebe0be9ffce7085257221/t/040-request.rakutest#L61) currently fails due to Content-Length now being auto-calculated / included
- [040-request.rakutest multipart implied by existing content-type subtest](https://github.com/zjmarlow/HTTP-UserAgent/blob/d6c4e7760f39265f8cdebe0be9ffce7085257221/t/040-request.rakutest#L97) currently fails due to missing trailing CRLF
- [050-response.rakutest parse - Str 1/4 testcase](https://github.com/zjmarlow/HTTP-UserAgent/blob/d6c4e7760f39265f8cdebe0be9ffce7085257221/t/050-response.rakutest#L36) currently fails due to Content-Length now being auto-calculated / included
- [170-request-common.rakutest POST - 3]() currently fails due to Content-Length now being calculated when Str is called

Could content handling (generating, parsing) be separated out?  It occurs in several places.